### PR TITLE
Allow "syntax error" messages to be suppressed.

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -418,7 +418,7 @@ bool CppCheck::checkFile(const std::string &code, const char FileName[], std::se
                                                e.id,
                                                false);
 
-        _errorLogger.reportErr(errmsg);
+        reportErr(errmsg);
     }
     return true;
 }


### PR DESCRIPTION
cppcheck fails to parse some complex C++ constructs. It would obviously be best if cppheck was able to parse these, but it is useful to be able to suppress the resulting syntax error messages when it cannot.
